### PR TITLE
Resolve a crash occurring during high concurrency requests.

### DIFF
--- a/include/log_state.h
+++ b/include/log_state.h
@@ -119,6 +119,20 @@ public:
                            uint64_t timestamp,
                            const std::string &log_message) = 0;
 
+    virtual int AddLogItemBatch(
+        const std::vector<std::tuple<uint64_t, uint64_t, std::string>>
+            &batch_logs)
+    {
+        int err = 0;
+        for (const auto &[tx, ts, log_message] : batch_logs)
+        {
+            err = AddLogItem(tx, ts, log_message);
+            if (err != 0)
+                break;
+        }
+        return err;
+    }
+
     virtual std::pair<bool, std::unique_ptr<ItemIterator>> GetLogReplayList(
         uint64_t start_timestamp) = 0;
 

--- a/include/log_state_rocksdb_impl.h
+++ b/include/log_state_rocksdb_impl.h
@@ -365,6 +365,10 @@ public:
                    uint64_t timestamp,
                    const std::string &log_message) override;
 
+    int AddLogItemBatch(
+        const std::vector<std::tuple<uint64_t, uint64_t, std::string>>
+            &batch_logs);
+
     std::pair<bool, std::unique_ptr<ItemIterator>> GetLogReplayList(
         uint64_t start_timestamp) override;
 

--- a/include/open_log_service.h
+++ b/include/open_log_service.h
@@ -131,7 +131,7 @@ public:
     {
     }
 
-    int Start(LogState *log_state, uint32_t worker_concurrency = 8);
+    int Start(LogState *log_state, uint32_t worker_concurrency = 4);
     void Shutdown();
 
     static void SetWriteLogErrorResponse(const WriteLogRequest &request,
@@ -142,7 +142,8 @@ private:
 
     const uint32_t log_group_id_;
     std::vector<std::unique_ptr<OpenLogTaskWorker>> workers_;
-    size_t task_counter_{0};
+    // received task counter per each LogService thread
+    static thread_local size_t received_task_cnt_;
 
     LogState *log_state_{nullptr};
     std::mutex log_replay_workers_mutex_;

--- a/include/open_log_task.h
+++ b/include/open_log_task.h
@@ -26,6 +26,8 @@
 #include <bthread/mutex.h>
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -71,5 +73,10 @@ private:
     std::vector<std::thread> worker_threads_;
     std::atomic<bool> stop_worker_;
     LogState *log_state_;
+
+    // Added for condition variable implementation
+    std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::atomic<uint32_t> task_cnt_{0};
 };
 }  // namespace txlog

--- a/include/open_log_task.h
+++ b/include/open_log_task.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <thread>
+#include <vector>
 
 #include "log.pb.h"
 
@@ -67,7 +68,6 @@ private:
                             LogResponse *resp);
 
     moodycamel::ConcurrentQueue<OpenLogServiceTask *> task_queue_;
-    moodycamel::ProducerToken producer_token_;
     std::vector<std::thread> worker_threads_;
     std::atomic<bool> stop_worker_;
     LogState *log_state_;

--- a/src/log_state_rocksdb_impl.cpp
+++ b/src/log_state_rocksdb_impl.cpp
@@ -283,7 +283,6 @@ int LogStateRocksDBImpl::Start()
         meta_handle_ = cfhs[1];
     }
 
-    // TODO(ZX) refactor this block
     // Recover meta data from RocksDB to log_state
     {
         rocksdb::ReadOptions read_options;

--- a/src/log_state_rocksdb_impl.cpp
+++ b/src/log_state_rocksdb_impl.cpp
@@ -47,11 +47,34 @@ LogStateRocksDBImpl::LogStateRocksDBImpl(std::string rocksdb_path,
       rocksdb_storage_path_(std::move(rocksdb_path)),
       sst_files_size_limit_(sst_files_size_limit),
       rocksdb_scan_threads_(rocksdb_scan_threads),
-      last_purging_sst_ckpt_ts_(0){};
+      last_purging_sst_ckpt_ts_(0) {};
 
 LogStateRocksDBImpl::~LogStateRocksDBImpl()
 {
     StopRocksDB();
+}
+
+int LogStateRocksDBImpl::AddLogItemBatch(
+    const std::vector<std::tuple<uint64_t, uint64_t, std::string>> &batch_logs)
+{
+    rocksdb::WriteBatch batch;
+
+    for (const auto &[tx_number, timestamp, log_message] : batch_logs)
+    {
+        std::array<char, 16> key{};
+        Serialize(key, timestamp, tx_number);
+        batch.Put(rocksdb::Slice(key.data(), key.size()), log_message);
+    }
+
+    rocksdb::Status status = db_->Write(write_option_, &batch);
+    if (!status.ok())
+    {
+        LOG(ERROR) << "batch add log items failed: " << status.ToString()
+                   << ", RocksDB error code: " << (int) status.code()
+                   << ", batch size: " << batch_logs.size();
+    }
+
+    return (int) status.code();
 }
 
 int LogStateRocksDBImpl::AddLogItem(uint64_t tx_number,
@@ -425,6 +448,7 @@ int LogStateRocksDBImpl::Start()
         }
     }
 
+    write_option_.disableWAL = false;
     write_option_.sync = true;
     LOG(INFO) << "The RocksDb log started.";
 

--- a/src/open_log_service.cpp
+++ b/src/open_log_service.cpp
@@ -26,6 +26,8 @@
 
 namespace txlog
 {
+thread_local size_t OpenLogServiceImpl::received_task_cnt_ = 0;
+
 void OpenLogServiceImpl::WriteLog(::google::protobuf::RpcController *controller,
                                   const LogRequest *request,
                                   LogResponse *response,
@@ -214,8 +216,8 @@ void OpenLogServiceImpl::SubmitAndWait(const LogRequest *req, LogResponse *resp)
     OpenLogServiceTask task{req, resp};
 
     assert(!workers_.empty());
-    size_t idx = task_counter_ % workers_.size();
-    ++task_counter_;
+    size_t idx = received_task_cnt_ % workers_.size();
+    ++received_task_cnt_;
     workers_[idx]->EnqueueTask(&task);
 
     std::unique_lock<bthread::Mutex> lk(task.mux_);

--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -23,6 +23,8 @@
 
 #include <mutex>
 #include <thread>
+#include <tuple>
+#include <vector>
 
 #include "log_state.h"
 #include "open_log_service.h"
@@ -47,7 +49,9 @@ void OpenLogTaskWorker::Shutdown()
 {
     stop_worker_.store(true, std::memory_order_release);
 
-    // Notify all waiting threads to check the stop flag
+    {
+        std::unique_lock<std::mutex> lk(queue_mutex_);
+    }
     queue_cv_.notify_all();
 
     for (auto &thread : worker_threads_)
@@ -71,9 +75,100 @@ void OpenLogTaskWorker::WorkerThreadMain()
         if (count > 0)
         {
             task_cnt_.fetch_sub(count, std::memory_order_relaxed);
+
+            // First pass: collect all data log writes from across tasks
+            std::vector<std::tuple<uint64_t, uint64_t, std::string>> batch_logs;
+            // Keep track of which tasks have data logs to update their
+            // responses later
+            std::vector<std::pair<OpenLogServiceTask *, size_t>> data_log_tasks;
+
+            // First pass: identify data log tasks and collect writes
             for (size_t i = 0; i < count; ++i)
             {
-                ProcessTask(tasks[i]);
+                OpenLogServiceTask *task = tasks[i];
+                const LogRequest *req = task->req_;
+
+                // Only batch kDataLog requests
+                if (req->request_case() ==
+                        LogRequest::RequestCase::kWriteLogRequest &&
+                    req->write_log_request().log_content().content_case() ==
+                        LogContentMessage::ContentCase::kDataLog)
+                {
+                    const WriteLogRequest &write_req = req->write_log_request();
+                    const uint64_t timestamp = write_req.commit_timestamp();
+                    uint64_t txn = write_req.txn_number();
+                    const DataLogMessage &data_log =
+                        write_req.log_content().data_log();
+
+                    // Record where this task's data logs start in batch_logs
+                    size_t start_index = batch_logs.size();
+                    data_log_tasks.emplace_back(task, start_index);
+
+                    // Add all log entries from this task to the batch
+                    for (auto it = data_log.node_txn_logs().begin();
+                         it != data_log.node_txn_logs().end();
+                         ++it)
+                    {
+                        batch_logs.emplace_back(txn, timestamp, it->second);
+                    }
+                }
+            }
+
+            // Perform batch write if there are data logs
+            int batch_err = 0;
+            if (!batch_logs.empty())
+            {
+                batch_err = log_state_->AddLogItemBatch(batch_logs);
+            }
+
+            // Second pass: process all tasks and set responses
+            for (size_t i = 0; i < count; ++i)
+            {
+                OpenLogServiceTask *task = tasks[i];
+                const LogRequest *req = task->req_;
+                LogResponse *resp = task->resp_;
+
+                // Check if this is a data log task we've already batched
+                bool is_batched_data_log = false;
+                for (const auto &[dl_task, start_index] : data_log_tasks)
+                {
+                    if (dl_task == task)
+                    {
+                        is_batched_data_log = true;
+
+                        // For batched data logs, use the batch error code
+                        if (batch_err != 0)
+                        {
+                            OpenLogServiceImpl::SetWriteLogErrorResponse(
+                                req->write_log_request(), resp);
+                        }
+                        else
+                        {
+                            resp->set_response_status(
+                                LogResponse::ResponseStatus::
+                                    LogResponse_ResponseStatus_Success);
+                        }
+
+                        // Update latest committed transaction number
+                        uint32_t tx_ident =
+                            req->write_log_request().txn_number() & 0xFFFFFFFF;
+                        log_state_->UpdateLatestCommittedTxnNumber(tx_ident);
+                        break;
+                    }
+                }
+
+                // Process non-data log tasks normally
+                if (!is_batched_data_log)
+                {
+                    ProcessTask(task);
+                }
+                else
+                {
+                    // For batched tasks, we still need to notify when complete
+                    std::unique_lock<bthread::Mutex> lk(task->mux_);
+                    task->finished_ = true;
+                    task->cv_.notify_one();
+                }
             }
         }
         else
@@ -130,11 +225,16 @@ void OpenLogTaskWorker::HandleWriteLog(const WriteLogRequest &req,
     case LogContentMessage::ContentCase::kDataLog:
     {
         const DataLogMessage &data_log = log_content.data_log();
+
+        // Process individual data log entries - batching is now done at
+        // WorkerThreadMain level
         for (auto it = data_log.node_txn_logs().begin();
              it != data_log.node_txn_logs().end();
              ++it)
         {
             err = log_state_->AddLogItem(txn, timestamp, it->second);
+            if (err != 0)
+                break;
         }
         break;
     }
@@ -182,6 +282,10 @@ void OpenLogTaskWorker::EnqueueTask(OpenLogServiceTask *task)
     task_queue_.enqueue(task);
 
     task_cnt_.fetch_add(1, std::memory_order_relaxed);
+
+    {
+        std::unique_lock<std::mutex> lk(queue_mutex_);
+    }
     queue_cv_.notify_one();
 }
 

--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -67,7 +67,7 @@ void OpenLogTaskWorker::Shutdown()
 
 void OpenLogTaskWorker::WorkerThreadMain()
 {
-    constexpr size_t MAX_BATCH_SIZE = 16;
+    constexpr size_t MAX_BATCH_SIZE = 256;
     OpenLogServiceTask *tasks[MAX_BATCH_SIZE];
 
     while (!stop_worker_.load(std::memory_order_relaxed))

--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -21,18 +21,15 @@
  */
 #include "open_log_task.h"
 
-#include <condition_variable>  // Include std::condition_variable
-#include <mutex>               // Include std::mutex
-#include <queue>               // Include std::queue
-#include <thread>              // Include std::thread
+#include <mutex>
+#include <thread>
 
 #include "log_state.h"
 #include "open_log_service.h"
 
 namespace txlog
 {
-OpenLogTaskWorker::OpenLogTaskWorker(size_t num_threads)
-    : producer_token_(task_queue_), stop_worker_(false)
+OpenLogTaskWorker::OpenLogTaskWorker(size_t num_threads) : stop_worker_(false)
 {
     for (size_t i = 0; i < num_threads; ++i)
     {
@@ -65,7 +62,6 @@ void OpenLogTaskWorker::WorkerThreadMain()
 
     while (!stop_worker_.load(std::memory_order_relaxed))
     {
-        // Try to dequeue multiple tasks at once
         size_t count = task_queue_.try_dequeue_bulk(tasks, MAX_BATCH_SIZE);
 
         if (count > 0)
@@ -170,7 +166,7 @@ void OpenLogTaskWorker::HandleUpdateCkptTs(const UpdateCheckpointTsRequest &req,
 
 void OpenLogTaskWorker::EnqueueTask(OpenLogServiceTask *task)
 {
-    task_queue_.enqueue(producer_token_, task);
+    task_queue_.enqueue(task);
 }
 
 }  // namespace txlog


### PR DESCRIPTION
1. Remove tokens used in ConcurrentQueue.
2. Use batch write for data log.