### PR TITLE
Fix schema operation replay.

### DIFF
--- a/include/log_shipping_agent.h
+++ b/include/log_shipping_agent.h
@@ -537,6 +537,7 @@ private:
         }
         if (global_max_ts > last_ckpt_ts_)
         {
+            assert(latest_txn_no_ <= global_latest_txn_no);
             latest_txn_no_ = global_latest_txn_no;
         }
 

--- a/include/log_shipping_agent.h
+++ b/include/log_shipping_agent.h
@@ -408,6 +408,9 @@ private:
                 schema_msg->clear_schema_op_blob();
                 schema_msg->set_schema_op_blob(item.log_message_);
                 schema_msg->set_txn(item.tx_number_);
+                LOG(INFO) << "write to stream schema_msg, commit_ts "
+                          << item.timestamp_ << ", tx_number "
+                          << item.tx_number_;
             }
             else if (item.item_type_ == LogItemType::SplitRangeLog)
             {

--- a/include/log_shipping_agent.h
+++ b/include/log_shipping_agent.h
@@ -408,9 +408,6 @@ private:
                 schema_msg->clear_schema_op_blob();
                 schema_msg->set_schema_op_blob(item.log_message_);
                 schema_msg->set_txn(item.tx_number_);
-                LOG(INFO) << "write to stream schema_msg, commit_ts "
-                          << item.timestamp_ << ", tx_number "
-                          << item.tx_number_;
             }
             else if (item.item_type_ == LogItemType::SplitRangeLog)
             {

--- a/include/log_state.h
+++ b/include/log_state.h
@@ -495,6 +495,8 @@ public:
                 if (new_stage == SplitRangeOpMessage_Stage_CommitSplit)
                 {
                     split_range_msg_copy = split_range_msg;
+                    split_range_msg_copy.clear_slice_keys();
+                    split_range_msg_copy.clear_slice_sizes();
                     assert(split_range_op_message.slice_keys_size() + 1 ==
                            split_range_op_message.slice_sizes_size());
                     int idx = 0;

--- a/include/log_state.h
+++ b/include/log_state.h
@@ -221,6 +221,10 @@ public:
     {
         std::unique_lock lk(log_state_mutex_);
         const SchemaOpMessage::Stage new_stage = schema_op.stage();
+
+        assert(!schema_op.table_name_str().empty() &&
+               schema_op.table_type() == CcTableType::Primary);
+
         if (new_stage == SchemaOpMessage_Stage_PrepareSchema)
         {
             if (tx_catalog_ops_.find(txn) != tx_catalog_ops_.end())
@@ -229,13 +233,6 @@ public:
                           << ", ignore";
                 return 0;
             }
-        }
-
-        assert(!schema_op.table_name_str().empty() &&
-               schema_op.table_type() == CcTableType::Primary);
-
-        if (new_stage == SchemaOpMessage_Stage_PrepareSchema)
-        {
             std::string schemas_op_str;
             assert(tx_catalog_ops_.find(txn) == tx_catalog_ops_.end());
             uint16_t cnt = 1;

--- a/include/log_state.h
+++ b/include/log_state.h
@@ -549,12 +549,7 @@ public:
 
     uint32_t LatestCommittedTxnNumber() const
     {
-        auto cc_ng_info_latest_txn_no =
-            cc_ng_info_.latest_txn_no_.load(std::memory_order_relaxed);
-        return cc_ng_info_latest_txn_no - latest_meta_tx_number_ <
-                       UINT32_MAX >> 1
-                   ? cc_ng_info_latest_txn_no
-                   : latest_meta_tx_number_;
+        return cc_ng_info_.latest_txn_no_;
     }
 
     void UpdateLatestCommittedTxnNumber(uint32_t tx_ident)
@@ -965,11 +960,5 @@ protected:
         ClusterScaleOpMessage cluster_scale_op_message_;
         uint64_t commit_ts_;
     };
-
-    /**
-     * Used for avoiding reusing tx number of tx which has not been replayed
-     */
-    uint64_t max_meta_commit_ts_{0};
-    uint32_t latest_meta_tx_number_{0};
 };
 }  // namespace txlog

--- a/include/log_state.h
+++ b/include/log_state.h
@@ -640,6 +640,11 @@ protected:
             const char *ptr = reinterpret_cast<const char *>(&tabname_len);
             split_range_op_str.append(ptr, sizeof(uint8_t));
             split_range_op_str.append(table_name.data(), tabname_len);
+            auto table_engine =
+                split_range_op.split_range_op_message_.table_engine();
+            const char *table_engine_ptr =
+                reinterpret_cast<const char *>(&table_engine);
+            split_range_op_str.append(table_engine_ptr, sizeof(uint8_t));
             // then, add split range op
             split_range_op.split_range_op_message_.AppendToString(
                 &split_range_op_str);

--- a/include/log_state_rocksdb_impl.h
+++ b/include/log_state_rocksdb_impl.h
@@ -405,7 +405,7 @@ public:
 private:
     int PersistSchemaOp(uint64_t txn,
                         uint64_t timestamp,
-                        const SchemaOpMessage &schema_op) override;
+                        const std::string &value) override;
 
     int PersistSchemasOp(
         uint64_t txn,

--- a/include/log_state_rocksdb_impl.h
+++ b/include/log_state_rocksdb_impl.h
@@ -405,7 +405,7 @@ public:
 private:
     int PersistSchemaOp(uint64_t txn,
                         uint64_t timestamp,
-                        const std::string &value) override;
+                        const std::string &schema_op_str) override;
 
     int PersistSchemasOp(
         uint64_t txn,
@@ -417,7 +417,7 @@ private:
 
     int PersistRangeOp(uint64_t txn,
                        uint64_t timestamp,
-                       const SplitRangeOpMessage &range_op) override;
+                       const std::string &range_op_str) override;
 
     int DeleteRangeOp(uint64_t txn, uint64_t timestamp) override;
 

--- a/src/log_state_rocksdb_impl.cpp
+++ b/src/log_state_rocksdb_impl.cpp
@@ -385,13 +385,13 @@ int LogStateRocksDBImpl::Start()
 
             uint64_t timestamp;
             uint64_t tx_number;
-            ::google::protobuf::RepeatedPtrField<SchemaOpMessage>
-                new_schemas_op_msg;
             SplitRangeOpMessage_Stage new_range_stage;
             SplitRangeOpMessage new_range_op_msg;
 
             while (it->Valid())
             {
+                ::google::protobuf::RepeatedPtrField<SchemaOpMessage>
+                    new_schemas_op_msg;
                 // Get the key and value as rocksdb::Slice
                 rocksdb::Slice key_slice = it->key();
                 rocksdb::Slice value_slice = it->value();
@@ -484,6 +484,7 @@ int LogStateRocksDBImpl::Start()
 
                 uint32_t latest_txn_no =
                     cc_ng_info_.latest_txn_no_.load(std::memory_order_relaxed);
+                // assuming the range of transaction number within UINT32_MAX/2
                 if (static_cast<int32_t>(
                         static_cast<uint32_t>(tx_number & 0xFFFFFFFF) -
                         latest_txn_no) > 0)
@@ -800,6 +801,7 @@ void LogStateRocksDBImpl::PurgingSstFiles()
     }
 }
 
+
 int LogStateRocksDBImpl::PersistSchemaOp(uint64_t txn,
                                          uint64_t timestamp,
                                          const std::string &schema_op_str)
@@ -859,7 +861,6 @@ int LogStateRocksDBImpl::PersistRangeOp(uint64_t txn,
                                         uint64_t timestamp,
                                         const std::string &range_op_str)
 {
-
     std::array<char, 17> key{};
     Serialize(key, timestamp, txn, static_cast<uint8_t>(MetaOp::RangeOp));
 

--- a/src/log_state_rocksdb_impl.cpp
+++ b/src/log_state_rocksdb_impl.cpp
@@ -821,7 +821,7 @@ int LogStateRocksDBImpl::PersistSchemasOp(
     const ::google::protobuf::RepeatedPtrField<SchemaOpMessage> &schemas_op)
 {
     std::array<char, 17> key{};
-    Serialize(key, timestamp, txn, (uint8_t) LogState::MetaOp::SchemaOp);
+    Serialize(key, timestamp, txn, static_cast<uint8_t>(MetaOp::SchemaOp));
 
     std::string schemas_op_str;
 
@@ -847,7 +847,7 @@ int LogStateRocksDBImpl::PersistSchemasOp(
 int LogStateRocksDBImpl::DeleteSchemaOp(uint64_t txn, uint64_t timestamp)
 {
     std::array<char, 17> key{};
-    Serialize(key, timestamp, txn, (uint8_t) LogState::MetaOp::SchemaOp);
+    Serialize(key, timestamp, txn, static_cast<uint8_t>(MetaOp::SchemaOp));
 
     rocksdb::Status rc = db_->Delete(
         write_option_, meta_handle_, rocksdb::Slice(key.data(), key.size()));

--- a/src/log_state_rocksdb_impl.cpp
+++ b/src/log_state_rocksdb_impl.cpp
@@ -479,6 +479,11 @@ int LogStateRocksDBImpl::Start()
                     }
                 }
 
+                if (timestamp > max_meta_commit_ts_)
+                {
+                    max_meta_commit_ts_ = timestamp;
+                    latest_meta_tx_number_ = static_cast<uint32_t>(tx_number & 0xFFFFFFFFu);
+                }
                 // Move to the next key
                 it->Next();
             }
@@ -833,6 +838,8 @@ int LogStateRocksDBImpl::PersistSchemaOp(uint64_t txn,
                 }
                 else
                 {
+                    LOG(INFO) << "stored stage: " << schema_op_msg_stored.stage()
+                    << ", new stage: " << schema_op_msg.stage();
                     return 1;
                 }
             }

--- a/src/open_log_service.cpp
+++ b/src/open_log_service.cpp
@@ -71,10 +71,10 @@ void OpenLogServiceImpl::ReplayLog(
     uint64_t last_ckpt_ts = log_state_->LastCkptTimestamp();
     // get log list since last_ckpt_ts+1
     // 0 indicates no checkpoint happened
-    LOG(INFO) << "ReplayLog last_ckpt_ts " << last_ckpt_ts << ", req.start_ts() " << req.start_ts();
     uint64_t start_ts = last_ckpt_ts == 0 ? 0 : last_ckpt_ts + 1;
     if (req.start_ts() != 0)
     {
+        LOG(INFO) << "ReplayLog requset to start from " << req.start_ts();
         start_ts = std::min(start_ts, req.start_ts());
     }
     LOG(INFO) << "Start replaying from timestamp " << start_ts;

--- a/src/open_log_service.cpp
+++ b/src/open_log_service.cpp
@@ -71,6 +71,7 @@ void OpenLogServiceImpl::ReplayLog(
     uint64_t last_ckpt_ts = log_state_->LastCkptTimestamp();
     // get log list since last_ckpt_ts+1
     // 0 indicates no checkpoint happened
+    LOG(INFO) << "ReplayLog last_ckpt_ts " << last_ckpt_ts << ", req.start_ts() " << req.start_ts();
     uint64_t start_ts = last_ckpt_ts == 0 ? 0 : last_ckpt_ts + 1;
     if (req.start_ts() != 0)
     {

--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -219,6 +219,7 @@ void OpenLogTaskWorker::HandleWriteLog(const WriteLogRequest &req,
 {
     const uint64_t timestamp = req.commit_timestamp();
     uint64_t txn = req.txn_number();
+    LOG(INFO) << "HandleWriteLog txn " << txn << " timestamp " << timestamp;
     int err = 0;
 
     const LogContentMessage &log_content = req.log_content();

--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -230,8 +230,10 @@ void OpenLogTaskWorker::HandleWriteLog(const WriteLogRequest &req,
 
         if (!data_log.schema_logs().empty())
         {
-            log_state_->UpsertSchemaOpWithinDML(
+            err = log_state_->UpsertSchemaOpWithinDML(
                 req.txn_number(), timestamp, data_log.schema_logs());
+            if (err != 0)
+                break;
         }
 
         // Process individual data log entries - batching is now done at
@@ -249,14 +251,14 @@ void OpenLogTaskWorker::HandleWriteLog(const WriteLogRequest &req,
     case LogContentMessage::ContentCase::kSchemaLog:
     {
         const SchemaOpMessage &schema_log = log_content.schema_log();
-        log_state_->UpsertSchemaOp(txn, timestamp, schema_log);
+        err = log_state_->UpsertSchemaOp(txn, timestamp, schema_log);
         break;
     }
     case LogContentMessage::ContentCase::kSplitRangeLog:
     {
         const SplitRangeOpMessage &split_range_op_message =
             log_content.split_range_log();
-        log_state_->UpdateSplitRangeOp(txn, timestamp, split_range_op_message);
+        err = log_state_->UpdateSplitRangeOp(txn, timestamp, split_range_op_message);
         break;
     }
     default:


### PR DESCRIPTION
Fix the bug in the serialization of schema operations. Since the schema operations can contain multiple messages now, the number of messages should also be serialized, which is missed, casuing the deserializing can get wrong value.

Fix the bug in parsing from rocksdb when starting. It's caused by wrongly using a RepeatedPtrField to parse all transactions information and mix log of different transactions into a single message.

Fix the bug in calculating the latest transaction number (txn). Currently, the txn of schema and range log is missed when calculating the latest txn when starting, making it possible that logservice returns a too small txn to txservice and a same txn is used twice, causing conflicts.
Also throw rocksdb error to avoid log service hang.