### PR TITLE
remove log of handling writelog

### DIFF
--- a/src/open_log_task.cpp
+++ b/src/open_log_task.cpp
@@ -219,7 +219,6 @@ void OpenLogTaskWorker::HandleWriteLog(const WriteLogRequest &req,
 {
     const uint64_t timestamp = req.commit_timestamp();
     uint64_t txn = req.txn_number();
-    LOG(INFO) << "HandleWriteLog txn " << txn << " timestamp " << timestamp;
     int err = 0;
 
     const LogContentMessage &log_content = req.log_content();


### PR DESCRIPTION
This log should be printed in every write log operation.